### PR TITLE
[FIX] 修复CVE-2020-1971

### DIFF
--- a/crypto/x509v3/v3_genn.c
+++ b/crypto/x509v3/v3_genn.c
@@ -107,6 +107,37 @@ GENERAL_NAME *GENERAL_NAME_dup(GENERAL_NAME *a)
                                     (char *)a);
 }
 
+static int edipartyname_cmp(const EDIPARTYNAME *a, const EDIPARTYNAME *b)
+{
+    int res;
+
+    if (a == NULL || b == NULL) {
+        /*
+         * Shouldn't be possible in a valid GENERAL_NAME, but we handle it
+         * anyway. OTHERNAME_cmp treats NULL != NULL so we do the same here
+         */
+        return -1;
+    }
+    if (a->nameAssigner == NULL && b->nameAssigner != NULL)
+        return -1;
+    if (a->nameAssigner != NULL && b->nameAssigner == NULL)
+        return 1;
+    /* If we get here then both have nameAssigner set, or both unset */
+    if (a->nameAssigner != NULL) {
+        res = ASN1_STRING_cmp(a->nameAssigner, b->nameAssigner);
+        if (res != 0)
+            return res;
+    }
+    /*
+     * partyName is required, so these should never be NULL. We treat it in
+     * the same way as the a == NULL || b == NULL case above
+     */
+    if (a->partyName == NULL || b->partyName == NULL)
+        return -1;
+
+    return ASN1_STRING_cmp(a->partyName, b->partyName);
+}
+
 /* Returns 0 if they are equal, != 0 otherwise. */
 int GENERAL_NAME_cmp(GENERAL_NAME *a, GENERAL_NAME *b)
 {
@@ -116,8 +147,11 @@ int GENERAL_NAME_cmp(GENERAL_NAME *a, GENERAL_NAME *b)
         return -1;
     switch (a->type) {
     case GEN_X400:
+        result = ASN1_TYPE_cmp(a->d.x400Address, b->d.x400Address);
+        break;
+
     case GEN_EDIPARTY:
-        result = ASN1_TYPE_cmp(a->d.other, b->d.other);
+        result = edipartyname_cmp(a->d.ediPartyName, b->d.ediPartyName);
         break;
 
     case GEN_OTHERNAME:
@@ -164,8 +198,11 @@ void GENERAL_NAME_set0_value(GENERAL_NAME *a, int type, void *value)
 {
     switch (type) {
     case GEN_X400:
+        a->d.x400Address = value;
+        break;
+
     case GEN_EDIPARTY:
-        a->d.other = value;
+        a->d.ediPartyName = value;
         break;
 
     case GEN_OTHERNAME:
@@ -199,8 +236,10 @@ void *GENERAL_NAME_get0_value(GENERAL_NAME *a, int *ptype)
         *ptype = a->type;
     switch (a->type) {
     case GEN_X400:
+        return a->d.x400Address;
+
     case GEN_EDIPARTY:
-        return a->d.other;
+        return a->d.ediPartyName;
 
     case GEN_OTHERNAME:
         return a->d.otherName;


### PR DESCRIPTION
## 修复链接参考：
Fixed in OpenSSL 1.1.1i (git commit: https://github.com/openssl/openssl/commit/f960d81215ebf3f65e03d4d5d857fb9b666d6920) (Affected 1.1.1-1.1.1h)
Fixed in OpenSSL 1.0.2x (git commit: https://github.com/openssl/openssl/commit/2154ab83e14ede338d2ede9bbe5cdfce5d5a6c9e) (Affected 1.0.2-1.0.2w)

## 漏洞描述
漏洞等级： 高危 ，漏洞评分： 7.5 。

OpenSSL 在处理 EDIPartyName (X.509 GeneralName类型)时，使用的函数 GENERAL_NAME_cmp 中存在一处空指针解引用。当使用该函数进行比较的两个参数都包含 EDIPartyName 时触发该漏洞。
GENERAL_NAME_cmp 函数在OpenSSL中主要作用为以下两点

    1. 比较X.509证书内的证书吊销列表和证书吊销分发节点中名称
    2. 验证响应令牌时间戳的签名者名称是否和时间戳许可者的名称一致