### PR TITLE
[FIX] 修复漏洞CVE-2021-23839

### DIFF
--- a/crypto/rsa/rsa_ssl.c
+++ b/crypto/rsa/rsa_ssl.c
@@ -104,7 +104,7 @@ int RSA_padding_add_SSLv23(unsigned char *to, int tlen,
 
 /*
  * Copy of RSA_padding_check_PKCS1_type_2 with a twist that rejects padding
- * if nul delimiter is not preceded by 8 consecutive 0x03 bytes. It also
+ * if nul delimiter is preceded by 8 consecutive 0x03 bytes. It also
  * preserves error code reporting for backward compatibility.
  */
 int RSA_padding_check_SSLv23(unsigned char *to, int tlen,
@@ -171,7 +171,13 @@ int RSA_padding_check_SSLv23(unsigned char *to, int tlen,
                                    RSA_R_NULL_BEFORE_BLOCK_MISSING);
     mask = ~good;
 
-    good &= constant_time_ge(threes_in_row, 8);
+    /*
+     * Reject if nul delimiter is preceded by 8 consecutive 0x03 bytes. Note
+     * that RFC5246 incorrectly states this the other way around, i.e. reject
+     * if it is not preceded by 8 consecutive 0x03 bytes. However this is
+     * corrected in subsequent errata for that RFC.
+     */
+    good &= constant_time_lt(threes_in_row, 8);
     err = constant_time_select_int(mask | good, err,
                                    RSA_R_SSLV3_ROLLBACK_ATTACK);
     mask = ~good;


### PR DESCRIPTION
## 链接参考
Fixed in OpenSSL 1.0.2y (git commit: https://github.com/openssl/openssl/commit/30919ab80a478f2d81f2e9acdcca3fa4740cd547) (Affected 1.0.2s-1.0.2x)

## 漏洞描述

低风险漏洞