### PR TITLE
[FIX] 修复漏洞CVE-2021-23841

### DIFF
--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -87,6 +87,8 @@ unsigned long X509_issuer_and_serial_hash(X509 *a)
 
     EVP_MD_CTX_init(&ctx);
     f = X509_NAME_oneline(a->cert_info->issuer, NULL, 0);
+    if (f == NULL)
+        goto err;
     if (!EVP_DigestInit_ex(&ctx, EVP_md5(), NULL))
         goto err;
     if (!EVP_DigestUpdate(&ctx, (unsigned char *)f, strlen(f)))


### PR DESCRIPTION
## 漏洞修复参考
Fixed in OpenSSL 1.1.1j (git commit: https://github.com/openssl/openssl/commit/122a19ab48091c657f7cb1fb3af9fc07bd557bbf) (Affected 1.1.1-1.1.1i)
Fixed in OpenSSL 1.0.2y (git commit: https://github.com/openssl/openssl/commit/8252ee4d90f3f2004d3d0aeeed003ad49c9a7807) (Affected 1.0.2-1.0.2x)

## 漏洞描述

中危漏洞