### PR TITLE
[FIX] 修复漏洞CVE-2022--0778

### DIFF
--- a/crypto/bn/bn_sqrt.c
+++ b/crypto/bn/bn_sqrt.c
@@ -64,7 +64,8 @@ BIGNUM *BN_mod_sqrt(BIGNUM *in, const BIGNUM *a, const BIGNUM *p, BN_CTX *ctx)
 /*
  * Returns 'ret' such that ret^2 == a (mod p), using the Tonelli/Shanks
  * algorithm (cf. Henri Cohen, "A Course in Algebraic Computational Number
- * Theory", algorithm 1.5.1). 'p' must be prime!
+ * Theory", algorithm 1.5.1). 'p' must be prime, otherwise an error or
+ * an incorrect "result" will be returned.
  */
 {
     BIGNUM *ret = in;
@@ -350,18 +351,23 @@ BIGNUM *BN_mod_sqrt(BIGNUM *in, const BIGNUM *a, const BIGNUM *p, BN_CTX *ctx)
             goto vrfy;
         }
 
-        /* find smallest  i  such that  b^(2^i) = 1 */
-        i = 1;
-        if (!BN_mod_sqr(t, b, p, ctx))
-            goto end;
-        while (!BN_is_one(t)) {
-            i++;
-            if (i == e) {
-                BNerr(BN_F_BN_MOD_SQRT, BN_R_NOT_A_SQUARE);
-                goto end;
+        /* Find the smallest i, 0 < i < e, such that b^(2^i) = 1. */
+        for (i = 1; i < e; i++) {
+            if (i == 1) {
+                if (!BN_mod_sqr(t, b, p, ctx))
+                    goto end;
+
+            } else {
+                if (!BN_mod_mul(t, t, t, p, ctx))
+                    goto end;
             }
-            if (!BN_mod_mul(t, t, t, p, ctx))
-                goto end;
+            if (BN_is_one(t))
+                break;
+        }
+        /* If not found, a is not a square or p is not prime. */
+        if (i >= e) {
+            BNerr(BN_F_BN_MOD_SQRT, BN_R_NOT_A_SQUARE);
+            goto end;
         }
 
         /* t := y^2^(e - i - 1) */


### PR DESCRIPTION
## 漏洞修复参考
Fixed in OpenSSL 1.1.1n (git commit: https://github.com/openssl/openssl/commit/3118eb64934499d93db3230748a452351d1d9a65) (Affected 1.1.1-1.1.1m)
Fixed in OpenSSL 1.0.2zd (git commit[not found]: https://github.com/openssl/openssl/commit/380085481c64de749a6dd25cdf0bcf4360b30f83) (Affected 1.0.2-1.0.2zc)

## 漏洞描述（已存在POC）
高危漏洞， 拒绝服务

由于证书解析时使用的 BN_mod_sqrt() 函数存在一个错误，它会导致在非质数的情况下永远循环。可通过生成包含无效的显式曲线参数的证书来触发无限循环。由于证书解析是在验证证书签名之前进行的，因此任何解析外部提供的证书的程序都可能受到拒绝服务攻击。此外，当解析特制的私钥时(包含显式椭圆曲线参数)，也可以触发无限循环。

因此易受攻击的情况如下：

    1. 使用服务器证书的 TLS 客户端
    2. 使用客户端证书的 TLS 服务器
    3. 托管服务提供商从客户处获取证书或私钥
    4. 证书颁发机构解析来自订阅者的认证请求
    5. 任何其他解析ASN.1椭圆曲线参数的程序

此外，任何使用BN_mod_sqrt()的其他应用程序，如果可以控制参数值，也会受到此漏洞影响。需要注意的是，任何需要证书中公钥的操作都会触发无限循环，特别是自签名的证书，在验证证书签名时会触发循环。