### PR TITLE
[FIX] 修改漏洞CVE-2022-1292

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ https://www.openssl.org/news/vulnerabilities.html
 openssl-1.0.2u受影响的漏洞列表
 ```
 --------2022--------
+CVE-2022-1292 (OpenSSL advisory) [Moderate severity] 03 May 2022: 
+Fixed in OpenSSL 1.0.2ze (git commit) (Affected 1.0.2-1.0.2zd)
+本仓库已修复： https://github.com/fdl66/openssl-1.0.2u-fix-cve/pull/9
+
 CVE-2022-0778 (OpenSSL advisory) [High severity] 15 March 2022: 
 Fixed in OpenSSL 1.0.2zd (git commit) (Affected 1.0.2-1.0.2zc)
 本仓库已修复： https://github.com/fdl66/openssl-1.0.2u-fix-cve/pull/7
@@ -43,7 +47,7 @@ Fixed in OpenSSL 1.0.2w (Affected 1.0.2-1.0.2v)
 
 
 ## 常用编译命令
-./config no-threads shared
+./config shared
 make -j4
 
 ## openssl的rpm包如何制作

--- a/tools/c_rehash.in
+++ b/tools/c_rehash.in
@@ -137,6 +137,23 @@ sub check_file {
 	return ($is_cert, $is_crl);
 }
 
+sub compute_hash {
+    my $fh;
+    if ( $^O eq "VMS" ) {
+        # VMS uses the open through shell
+        # The file names are safe there and list form is unsupported
+        if (!open($fh, "-|", join(' ', @_))) {
+            print STDERR "Cannot compute hash on '$fname'\n";
+            return;
+        }
+    } else {
+        if (!open($fh, "-|", @_)) {
+            print STDERR "Cannot compute hash on '$fname'\n";
+            return;
+        }
+    }
+    return (<$fh>, <$fh>);
+}
 
 # Link a certificate to its subject name hash value, each hash is of
 # the form <hash>.<n> where n is an integer. If the hash value already exists
@@ -146,10 +163,12 @@ sub check_file {
 
 sub link_hash_cert {
 		my $fname = $_[0];
-		$fname =~ s/'/'\\''/g;
-		my ($hash, $fprint) = `"$openssl" x509 $x509hash -fingerprint -noout -in "$fname"`;
+		my ($hash, $fprint) = compute_hash($openssl, "x509", $x509hash,
+										   "-fingerprint", "-noout",
+										   "-in", $fname);
 		chomp $hash;
 		chomp $fprint;
+		return if !$hash;
 		$fprint =~ s/^.*=//;
 		$fprint =~ tr/://d;
 		my $suffix = 0;
@@ -181,10 +200,12 @@ sub link_hash_cert {
 
 sub link_hash_crl {
 		my $fname = $_[0];
-		$fname =~ s/'/'\\''/g;
-		my ($hash, $fprint) = `"$openssl" crl $crlhash -fingerprint -noout -in '$fname'`;
+		my ($hash, $fprint) = compute_hash($openssl, "crl", $crlhash,
+										   "-fingerprint", "-noout",
+										   "-in", $fname);
 		chomp $hash;
 		chomp $fprint;
+		return if !$hash;
 		$fprint =~ s/^.*=//;
 		$fprint =~ tr/://d;
 		my $suffix = 0;


### PR DESCRIPTION
## 漏洞修复参考
Fixed in OpenSSL 1.1.1o [(git commit)](https://github.com/openssl/openssl/commit/e5fd1728ef4c7a5bf7c7a7163ca60370460a6e23) (Affected 1.1.1-1.1.1n)
Fixed in OpenSSL 1.0.2ze [(git commit)](https://github.com/openssl/openssl/commit/548d3f280a6e737673f5b61fce24bb100108dfeb) (Affected 1.0.2-1.0.2zd)

## 漏洞描述
OpenSSL命令注入漏洞 （中危）
影响版本： OpenSSL 1.0.2-1.0.2zd

由于c_rehash 脚本没有正确清理 shell 元字符导致命令注入，可以利用该漏洞在未授权的情况下以脚本的权限执行任意命令。

